### PR TITLE
Make sgtk publish operations atomic and undo-able

### DIFF
--- a/hooks/basic/publish_files.py
+++ b/hooks/basic/publish_files.py
@@ -470,9 +470,23 @@ class PublishFilesPlugin(HookBaseClass):
 
         # create the publish and stash it in the item properties for other
         # plugins to use.
-        item.properties["sg_publish_data"] = sgtk.util.register_publish(
-            **publish_data)
-        self.logger.info("Publish registered!")
+        try:
+            item.properties["sg_publish_data"] = sgtk.util.register_publish(
+                **publish_data)
+            self.logger.info("Publish registered!")
+        except Exception:
+            # cleanup the copied files since we couldn't create a PublishedFile entity
+            self._delete_files(publish_path, item)
+            self.logger.error(
+                "Couldn't register Publish for %s" % item.name,
+                extra={
+                    "action_show_more_info": {
+                        "label": "Show Error Log",
+                        "tooltip": "Show the error log",
+                        "text": traceback.format_exc()
+                    }
+                }
+            )
 
 
     def finalize(self, task_settings, item):
@@ -487,29 +501,30 @@ class PublishFilesPlugin(HookBaseClass):
         :param item: Item to process
         """
 
-        publisher = self.parent
+        if "sg_publish_data" in item.properties:
+            publisher = self.parent
 
-        # get the data for the publish that was just created in SG
-        publish_data = item.properties["sg_publish_data"]
+            # get the data for the publish that was just created in SG
+            publish_data = item.properties["sg_publish_data"]
 
-        # ensure conflicting publishes have their status cleared
-        publisher.util.clear_status_for_conflicting_publishes(
-            item.context, publish_data)
+            # ensure conflicting publishes have their status cleared
+            publisher.util.clear_status_for_conflicting_publishes(
+                item.context, publish_data)
 
-        self.logger.info(
-            "Cleared the status of all previous, conflicting publishes")
+            self.logger.info(
+                "Cleared the status of all previous, conflicting publishes")
 
-        path = item.properties["path"]
-        self.logger.info(
-            "Publish created for file: %s" % (path,),
-            extra={
-                "action_show_in_shotgun": {
-                    "label": "Show Publish",
-                    "tooltip": "Open the Publish in Shotgun.",
-                    "entity": publish_data
+            path = item.properties["path"]
+            self.logger.info(
+                "Publish created for file: %s" % (path,),
+                extra={
+                    "action_show_in_shotgun": {
+                        "label": "Show Publish",
+                        "tooltip": "Open the Publish in Shotgun.",
+                        "entity": publish_data
+                    }
                 }
-            }
-        )
+            )
 
 
     ############################################################################

--- a/hooks/maya/publish_files.py
+++ b/hooks/maya/publish_files.py
@@ -125,9 +125,11 @@ class MayaPublishFilesPlugin(HookBaseClass):
 
         super(MayaPublishFilesPlugin, self).finalize(task_settings, item)
 
-        # insert the path into the properties
-        if item.type == 'file.maya':
-            item.properties["next_version_path"] = self._bump_file_version(path)
+        # only version up the file if the publish went through successfully.
+        if item.properties.get("sg_publish_data"):
+            # insert the path into the properties
+            if item.type == 'file.maya':
+                item.properties["next_version_path"] = self._bump_file_version(path)
 
 
     def _bump_file_version(self, path):

--- a/hooks/nuke/publish_files.py
+++ b/hooks/nuke/publish_files.py
@@ -192,9 +192,11 @@ class NukePublishFilesPlugin(HookBaseClass):
 
         super(NukePublishFilesPlugin, self).finalize(task_settings, item)
 
-        # insert the path into the properties
-        if item.type == 'file.nuke':
-            item.properties["next_version_path"] = self._bump_file_version(path)
+        # only version up the file if the publish went through successfully.
+        if item.properties.get("sg_publish_data"):
+            # insert the path into the properties
+            if item.type == 'file.nuke':
+                item.properties["next_version_path"] = self._bump_file_version(path)
 
 
     def _bump_file_version(self, path):

--- a/python/tk_multi_publish2/base_hooks/publish_plugin.py
+++ b/python/tk_multi_publish2/base_hooks/publish_plugin.py
@@ -458,6 +458,37 @@ class PublishPlugin(PluginBase):
         """
         raise NotImplementedError
 
+    def undo(self, task_settings, item):
+        """
+        Cleans up the products created after a publish for an item.
+
+        This method can be used to delete any files or entities that were
+        created as a part of the publish process.
+
+        Any raised exceptions will have to be handled within this method itself.
+
+        Simple implementation example of deleting a PublishedFile entity and the corresponding files on disk:
+
+        .. code-block:: python
+
+            def undo(self, task_settings, item):
+
+                publish_data = item.properties.get("sg_publish_data")
+                publish_path = item.properties.get("publish_path")
+                self._delete_files(publish_path, item)
+                if publish_data:
+                    try:
+                        self.sgtk.shotgun.delete(publish_data["type"], publish_data["id"])
+                    except Exception:
+                        self.logger.error("Failed to delete the PublishedFile entity for %s" % item.name)
+
+        :param dict task_settings: The keys are strings, matching the keys returned
+            in the :data:`settings` property. The values are
+            :class:`~.processing.Setting` instances.
+        :param item: The :class:`~.processing.Item` instance to validate.
+        """
+        raise NotImplementedError
+
     ############################################################################
     # Methods for creating/displaying custom plugin interface
 


### PR DESCRIPTION
added delete_files method to base_hooks of publish_plugin if the PublishedFile fails to create the actions cleans up the files copied to publish_path