### PR TITLE
#bug-558: tk-multi-publish2: item frame range incorrect

### DIFF
--- a/hooks/path_info.py
+++ b/hooks/path_info.py
@@ -349,7 +349,7 @@ class BasicPathInfo(HookBaseClass):
             seq_path = seq_info["sequence_path"]
 
             logger.debug("Found sequence: %s" % (seq_path,))
-            frame_sequences.append((seq_path, seq_info["file_list"]))
+            frame_sequences.append((seq_path, sorted(seq_info["file_list"])))
 
         return frame_sequences
 


### PR DESCRIPTION
Fixing get_frame_sequences in hooks/path_info.py to return sorted files_list.