### PR TITLE
#599: explicitly set the file extension abc for export geometry

### DIFF
--- a/hooks/maya/collector.py
+++ b/hooks/maya/collector.py
@@ -208,6 +208,7 @@ class MayaSessionCollector(HookBaseClass):
         )
 
         geo_item.set_icon_from_path(icon_path)
+        geo_item.properties["fields"].update({"extension": "abc"})
 
         self.logger.info("Collected item: Maya Session Geometry")
         return [geo_item]


### PR DESCRIPTION
Read from parent, this takes 'ma' as the extension and fails.
Set the file extension in the accept method, so that validate and publish can use it.