### PR TITLE
updating sg_path_to_source field with the path property of item

### DIFF
--- a/hooks/basic/publish_files.py
+++ b/hooks/basic/publish_files.py
@@ -477,6 +477,7 @@ class PublishFilesPlugin(HookBaseClass):
             "context": item.context,
             "comment": item.description,
             "path": publish_path,
+            "sg_path_to_source": item.properties.path,
             "name": publish_name,
             "version_number": publish_version,
             "thumbnail_path": item.get_thumbnail_as_path() or "",


### PR DESCRIPTION
This field has been added to trace back to the original file that was copied for this publish file.