### PR TITLE
#1270: enable safe context switching for the items

### DIFF
--- a/python/tk_multi_publish2/dialog.py
+++ b/python/tk_multi_publish2/dialog.py
@@ -1376,7 +1376,7 @@ class AppDialog(QtGui.QWidget):
                     # this item and all of its descendents in the tree need to
                     # have their plugins reattached given the new context
                     # items_with_new_context.append(top_level_item)
-                    # items_with_new_context.extend([i for i in top_level_item])
+                    # items_with_new_context.extend([i for i in top_level_item.children])
 
                     num_errors = self._progress_handler.pop()
                     sync_required = True
@@ -1390,12 +1390,12 @@ class AppDialog(QtGui.QWidget):
                 # this item and all of its descendents in the tree need to have
                 # their plugins reattached given the new context
                 # items_with_new_context.append(self._current_item)
-                # items_with_new_context.extend([i for i in self._current_item])
+                # items_with_new_context.extend([i for i in self._current_item.children])
 
                 num_errors = self._progress_handler.pop()
                 sync_required = True
 
-        # TODO: attach plugins for the destination context. this is commented
+        # TODO: attach plugins for the destination context. this is commented, coz it is handled in on_context_changed
         # out for now as it is a change in behavior and likely implies some
         # additional things to consider. for example: the drag/drop of items
         # within the tree (which changes context) will need to be updated. will
@@ -1405,7 +1405,7 @@ class AppDialog(QtGui.QWidget):
         # ...
         # for any items that have a new context, rerun plugin attachment so that
         # they are published using the destination context's plugins
-        # self._publish_manager.attach_plugins(items_with_new_context)
+        # self._publish_manager._attach_plugins(items_with_new_context)
 
         if num_errors == 0:
             self._progress_handler.logger.info("Context successfully updated.")

--- a/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
+++ b/python/tk_multi_publish2/publish_tree_widget/publish_tree_widget.py
@@ -181,7 +181,8 @@ class PublishTreeWidget(QtGui.QTreeWidget):
             # TODO: because the context has changed for these items, the attached
             # tasks for the underlying item will be different. make sure the old
             # ones are replaced with the new
-            # self.__rebuild_tasks_r(item)
+            self.__rebuild_tasks_r(item)
+            # already being called in insert item.
             # _init_item_r(item)
 
         # pass 2 - check that there aren't any dangling contexts


### PR DESCRIPTION
These are not the final commits, I will cleanup the unused code before merging.
The following changes have just un-commented the `TODO` by shotgunsoftware, without other API changes.