### PR TITLE
#1596: for non-sequence items, set seq fields to None in collector

### DIFF
--- a/hooks/collector.py
+++ b/hooks/collector.py
@@ -12,6 +12,7 @@ import copy
 import datetime
 import urllib
 import sgtk
+from sgtk.templatekey import SequenceKey
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -238,5 +239,11 @@ class CollectorPlugin(HookBaseClass):
         elif item.context.task:
             name_field = item.context.task["name"]
             fields["name"] = urllib.quote(name_field.replace(" ", "_").lower(), safe='')
+
+        # if item is not a sequence, set all sequence keys explicitly to None
+        if not item.get_property("is_sequence"):
+            for key in self.sgtk.template_keys.values():
+                if isinstance(key, SequenceKey):
+                    fields[key.name] = None
 
         return fields

--- a/hooks/publish.py
+++ b/hooks/publish.py
@@ -782,12 +782,6 @@ class PublishPlugin(HookBaseClass):
                 # this template was not found in the template config!
                 raise TankError("The Template '%s' does not exist!" % publish_path_template)
 
-            # if item is not a sequence, set all sequence keys explicitly to None
-            if not item.get_property("is_sequence"):
-                for key in pub_tmpl.keys.values():
-                    if isinstance(key, SequenceKey):
-                        fields[key.name] = None
-
             # First get the fields from the context
             try:
                 fields.update(item.context.as_template_fields(pub_tmpl))


### PR DESCRIPTION
Moved to collector from get_publish_path() so all templates are affected correctly.