### PR TITLE
#3595: do not forcefully set child item's context to parent

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -359,8 +359,8 @@ class PublishItem(object):
         child_item._global_properties = PublishData.from_dict(properties or {})
 
         # Set the context on the child item if defined
-        context = context or self.context
-        child_item.context = context
+        if context:
+            child_item.context = context
 
         return child_item
 
@@ -636,6 +636,10 @@ class PublishItem(object):
         """
         if not self.context_change_allowed:
             raise AttributeError("Context change for item '%s' not allowed." % self.name)
+
+        if self._context == item_context:
+            # context doesn't need to be changed
+            return
 
         self._context = item_context
 


### PR DESCRIPTION
getter handles that without the explicit storage. This prevents resolve_item_fields being called again unnecessarily.