### PR TITLE
#4715: publish conflicts - remove task, code filters to get all versions

### DIFF
--- a/python/tk_multi_publish2/util.py
+++ b/python/tk_multi_publish2/util.py
@@ -619,7 +619,7 @@ def get_conflicting_publishes(context, path, publish_name, filters=None):
 
     # now build up the filters to match against
     publish_filters = [filters] if filters else []
-    for field in ["code", "entity", "name", "project", "task"]:
+    for field in ["entity", "name", "project"]:
         publish_filters.append([field, "is", publish_data[field]])
     logger.debug("Build publish filters: %s" % (publish_filters,))
 


### PR DESCRIPTION
Code includes the version, so we are not getting the higher versions now. Also, tasks can have the same name leading to the same publish path, which should be caught here instead of raising permission error at write time.