### PR TITLE
#5119 - added id property to PluginInstanceBase

### DIFF
--- a/python/tk_multi_publish2/api/item.py
+++ b/python/tk_multi_publish2/api/item.py
@@ -1163,7 +1163,7 @@ class PublishItem(object):
                 (hook_object,)
             )
 
-        plugin_id = hook_object.id
+        plugin_id = hook_object.plugin.id
 
         return self._local_properties[plugin_id]
 

--- a/python/tk_multi_publish2/api/plugins/collector_instance.py
+++ b/python/tk_multi_publish2/api/plugins/collector_instance.py
@@ -26,6 +26,17 @@ class CollectorPluginInstance(PluginInstanceBase):
     Each collector plugin object reflects an instance in the app configuration.
     """
 
+    def __init__(self, path, context, publish_logger):
+        """
+        Initialize a plugin instance.
+
+        :param path: Path to the collector hook
+        :param context: The Context to use to resolve this plugin's settings
+        :param publish_logger: a logger object that will be used by the hook
+        """
+
+        super(CollectorPluginInstance, self).__init__("Collector", path, context, publish_logger)
+
     def _create_hook_instance(self, path):
         """
         Create the plugin's hook instance.
@@ -34,13 +45,13 @@ class CollectorPluginInstance(PluginInstanceBase):
         implementation.
         """
         bundle = sgtk.platform.current_bundle()
-        plugin = bundle.create_hook_instance(
+        hook = bundle.create_hook_instance(
             path,
             base_class=bundle.base_hooks.CollectorPlugin,
             plugin=self
         )
-        plugin.id = path
-        return plugin
+        hook.id = path
+        return hook
 
     def get_plugin_settings(self, context=None):
         """

--- a/python/tk_multi_publish2/api/plugins/instance_base.py
+++ b/python/tk_multi_publish2/api/plugins/instance_base.py
@@ -22,7 +22,7 @@ class PluginInstanceBase(object):
     Each object reflects an instance in the app configuration.
     """
 
-    def __init__(self, path, context, publish_logger):
+    def __init__(self, name, path, context, publish_logger):
         """
         Initialize a plugin instance.
 
@@ -39,7 +39,9 @@ class PluginInstanceBase(object):
         self._logger = publish_logger
 
         # all plugins need a hook and a name
+        self._name = name
         self._path = path
+        self._id = (self._name, self._path)
         self._context = context
 
         self._settings = {}
@@ -49,6 +51,17 @@ class PluginInstanceBase(object):
 
         # kick things off
         self._validate_and_resolve_config()
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def name(self):
+        """
+        The name of this publish plugin instance
+        """
+        return self._name
 
     def _create_hook_instance(self, path):
         """

--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -33,12 +33,10 @@ class PublishPluginInstance(PluginInstanceBase):
         :param context: The Context to use to resolve this plugin's settings
         :param publish_logger: a logger object that will be used by the hook
         """
-        # all plugins need a hook and a name
-        self._name = name
-
         self._icon_pixmap = None
 
         super(PublishPluginInstance, self).__init__(
+            name,
             path,
             context,
             publish_logger
@@ -57,15 +55,9 @@ class PublishPluginInstance(PluginInstanceBase):
             base_class=bundle.base_hooks.PublishPlugin,
             plugin=self
         )
+        # hook.id = (path, self.name)
         hook.id = path
         return hook
-
-    @property
-    def name(self):
-        """
-        The name of this publish plugin instance
-        """
-        return self._name
 
     @property
     def plugin_name(self):

--- a/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
+++ b/python/tk_multi_publish2/api/plugins/publish_plugin_instance.py
@@ -55,7 +55,7 @@ class PublishPluginInstance(PluginInstanceBase):
             base_class=bundle.base_hooks.PublishPlugin,
             plugin=self
         )
-        # hook.id = (path, self.name)
+
         hook.id = path
         return hook
 


### PR DESCRIPTION
item.local_properties is supposed to be distinct for each plugin, but it was using hook id as a plugin id, which is the hook path, and in one of our test cases, resulted in both plugins being considered the same. Added an id property to PluginInstanceBase so that we have a unique identifier.